### PR TITLE
Update installMacStuff.sh

### DIFF
--- a/bin/installMacStuff.sh
+++ b/bin/installMacStuff.sh
@@ -64,7 +64,7 @@ if ! $FAST ; then
 fi
 
 # Install stuff using homebrew
-brew install vim --override-system-vi --override-system-vim
+brew install vim --override-system-vi --with-override-system-vi
 brew install htop --with-ncurses
 brew install coreutils zsh wget screen mc
 


### PR DESCRIPTION
These warnings occurred at my site (osX Sierra 10.12.3):
Warning: vim: --override-system-vi was deprecated; using --with-override-system-vi instead!
Warning: vim: this formula has no --override-system-vim option so it will be ignored!